### PR TITLE
Fix alignment type in showAnimatedDialog function

### DIFF
--- a/lib/src/animated_dialog.dart
+++ b/lib/src/animated_dialog.dart
@@ -74,7 +74,7 @@ Future<T> showAnimatedDialog<T>({
   DialogTransitionType animationType = DialogTransitionType.fade,
   Curve curve = Curves.linear,
   Duration? duration,
-  AlignmentGeometry alignment = Alignment.center,
+  Alignment alignment = Alignment.center,
   Axis? axis,
 }) {
   assert(builder != null);
@@ -188,7 +188,7 @@ Future<T> showAnimatedDialog<T>({
           );
         case DialogTransitionType.scale:
           return ScaleTransition(
-            alignment: alignment as Alignment, // Cast to Alignment
+            alignment: alignment,
             scale: CurvedAnimation(
               parent: animation,
               curve: Interval(
@@ -201,7 +201,7 @@ Future<T> showAnimatedDialog<T>({
           );
         case DialogTransitionType.fadeScale:
           return ScaleTransition(
-            alignment: alignment as Alignment, // Cast to Alignment
+            alignment: alignment,
             scale: CurvedAnimation(
               parent: animation,
               curve: Interval(
@@ -220,7 +220,7 @@ Future<T> showAnimatedDialog<T>({
           );
         case DialogTransitionType.scaleRotate:
           return ScaleTransition(
-            alignment: alignment as Alignment, // Cast to Alignment
+            alignment: alignment,
             scale: CurvedAnimation(
               parent: animation,
               curve: Interval(


### PR DESCRIPTION
Update the `alignment` parameter type in `showAnimatedDialog` function to `Alignment` in `lib/src/animated_dialog.dart`.

* Change the type of the `alignment` parameter from `AlignmentGeometry` to `Alignment`.
* Remove unnecessary casting of `alignment` to `Alignment` in the `ScaleTransition` and `ScaleRotate` cases.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sctnightcore/flutter_animated_dialog/pull/3?shareId=1efd362a-b9fc-4e33-98f1-b266f5b15bea).