### PR TITLE
Fix return type of showAnimatedDialog function

### DIFF
--- a/lib/src/animated_dialog.dart
+++ b/lib/src/animated_dialog.dart
@@ -67,7 +67,7 @@ enum DialogTransitionType {
 }
 
 /// Displays a Material dialog above the current contents of the app
-Future<T> showAnimatedDialog<T>({
+Future<Object?> showAnimatedDialog({
   required BuildContext context,
   bool barrierDismissible = false,
   required WidgetBuilder builder,


### PR DESCRIPTION
Change the return type of the `showAnimatedDialog` function to `Future<Object?>` in `lib/src/animated_dialog.dart`.

* Update the function signature to match the new return type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sctnightcore/flutter_animated_dialog/pull/4?shareId=0a280d4e-4f94-4787-8008-a73fc14c1198).