### PR TITLE
Fix error assigning DialogThemeData to DialogTheme

### DIFF
--- a/lib/src/animated_dialog.dart
+++ b/lib/src/animated_dialog.dart
@@ -80,7 +80,7 @@ Future<Object?> showAnimatedDialog({
   assert(builder != null);
   assert(debugCheckHasMaterialLocalizations(context));
 
-  final ThemeData theme = Theme.of(context);
+  final DialogTheme theme = DialogTheme.of(context);
 
   isShowing = true;
   return showGeneralDialog(
@@ -92,7 +92,7 @@ Future<Object?> showAnimatedDialog({
         top: false,
         child: Builder(builder: (BuildContext context) {
           return theme != null
-              ? Theme(data: theme, child: pageChild)
+              ? Theme(data: Theme.of(context), child: pageChild)
               : pageChild;
         }),
       );


### PR DESCRIPTION
Fix the error regarding assigning a value of type 'DialogThemeData' to a variable of type 'DialogTheme' in `lib/src/animated_dialog.dart`.

* Update the `theme` variable assignment in the `showAnimatedDialog` function to use `DialogTheme.of(context)` instead of `Theme.of(context)`.
* Ensure the `theme` variable is of type `DialogTheme`.
* Modify the `Theme` widget to use `Theme.of(context)` instead of `theme` for the `data` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sctnightcore/flutter_animated_dialog/pull/5?shareId=9360a8e7-9d3a-4603-a0e8-ddb4f5f542b7).